### PR TITLE
Fixing logger printing bug

### DIFF
--- a/basevertex.py
+++ b/basevertex.py
@@ -1,5 +1,5 @@
 import pdb
-from logger import logger
+import logger
 from introspect import Introspect
 from contrail_utils import ContrailUtils
 from utils import Utils
@@ -41,7 +41,7 @@ def create_global_context(**kwargs):
 def get_logger(name, **kwargs):
     verbose = kwargs.get('verbose', None)
     loglevel = logging.DEBUG if verbose else logging.INFO
-    return logger(logger_name=name, file_level=loglevel).get_logger()
+    return logger.getLogger(logger_name=name, console_level=loglevel)
 
 def create_vertex(vertex_type, **kwargs):
     vertex = defaultdict(dict)

--- a/contrail_api.py
+++ b/contrail_api.py
@@ -3,7 +3,7 @@ import pdb
 import pprint
 import json
 import re
-from logger import logger
+import logger
 from urlparse import urlparse
 from contrail_api_con import ContrailApiConnection
 from contrail_api_con_exception import ContrailApiConnectionException
@@ -17,7 +17,7 @@ class ContrailApi:
     }
 
     def __init__(self, ip = "127.0.0.1", port = "8082", token=None):
-        self.log = logger(logger_name=self.__class__.__name__).get_logger()
+        self.log = logger.getLogger(logger_name=self.__class__.__name__)
         self._ip = ip
         self._port = port
         token_header = {'X-AUTH-TOKEN': token} if token else {}

--- a/contrail_api_con.py
+++ b/contrail_api_con.py
@@ -3,7 +3,7 @@ import pdb
 import re
 import pprint
 import json
-from logger import logger
+import logger
 from utils import Utils
 from contrail_api_con_exception import ContrailApiConnectionException
 from contrail_con_enum import ContrailConError
@@ -18,7 +18,7 @@ except ImportError:
 
 class ContrailApiConnection:
     def  __init__(self, ip = None, port = None, headers = None):
-        self.log =  logger(logger_name=self.__class__.__name__).get_logger()
+        self.log =  logger.getLogger(logger_name=self.__class__.__name__)
         self.ip = ip
         self.port = port
 	if (ip == None or port == None):

--- a/contrail_uve.py
+++ b/contrail_uve.py
@@ -1,6 +1,6 @@
 #!/bin/python
 import pdb
-from logger import logger
+import logger
 import pprint
 import json
 import re
@@ -9,7 +9,7 @@ from contrail_api_con import ContrailApiConnection
 
 class ContrailUVE:
     def __init__(self, ip = "127.0.0.1", port = "8081", token=None):
-        self.log = logger(logger_name=self.__class__.__name__).get_logger()
+        self.log = logger.getLogger(logger_name=self.__class__.__name__)
         token_header = {'X-AUTH-TOKEN': token} if token else {}
         self._api_con = ContrailApiConnection(ip=ip, port=port,
                                               headers=token_header)

--- a/debugfip.py
+++ b/debugfip.py
@@ -23,7 +23,7 @@ class debugVertexFIP(baseVertex):
     def process_self(self, vertex):
         # Update flaotingip address if doesnt exist
         if not self.floating_ip_address:
-            self.floating_ip_address = vertex['floating-ip']['floating_ip_address']
+            self.floating_ip_address = self.get_attr('floating_ip_address', vertex)
         # Agent
         agent = {}
         agent['oper'] = self.agent_oper_db(self._get_agent_oper_db, vertex)

--- a/introspect.py
+++ b/introspect.py
@@ -2,7 +2,7 @@
 """Retrieve or Query an object from introspects"""
 
 import requests
-from logger import logger
+import logger
 from lxml import etree
 from netaddr import IPNetwork, IPAddress
 
@@ -100,7 +100,7 @@ class Introspect(object):
         self._ip = ip
         self._port = port
         self._headers = {'X-AUTH-TOKEN': auth} if auth else None
-        self.log = logger(logger_name=self.__class__.__name__).get_logger()
+        self.log = logger.getLogger(logger_name=self.__class__.__name__)
 
     def _mk_url_str(self, path=''):
         if path.startswith('http:'):

--- a/keystone_auth.py
+++ b/keystone_auth.py
@@ -2,7 +2,7 @@
 import pdb
 import json
 import re
-from logger import logger
+import logger
 import ConfigParser
 import os.path
 from contrail_api_con import ContrailApiConnection
@@ -13,7 +13,7 @@ class ContrailKeystoneAuth:
         self._authn_user = admin_username
         self._authn_password = admin_password
         self._authn_tenant_name = admin_tenant_name
-        self.log = logger(logger_name='KeystoneAuth').get_logger()
+        self.log = logger.getLogger(logger_name='KeystoneAuth')
         self._keystone_con = ContrailApiConnection(ip=auth_ip, port=auth_port)
 
     def authenticate(self):

--- a/logger.py
+++ b/logger.py
@@ -1,8 +1,18 @@
 import logging
 from logging.handlers import RotatingFileHandler
+c_level = logging.ERROR
+_loggers = {}
+
+def getLogger(logger_name=None, console_level=None, **kwargs):
+    global c_level
+    c_level = console_level or c_level
+    if logger_name not in _loggers:
+        _loggers[logger_name] = logger(logger_name=logger_name,
+                                       console_level=c_level, **kwargs)
+    return _loggers[logger_name].get_logger()
 
 class logger(object):
-    def __init__(self, context=None, **kwargs):
+    def __init__(self, **kwargs):
         console_level = kwargs.get('console_level', logging.ERROR)
         file_level = kwargs.get('file_level', logging.DEBUG)
         log_file = kwargs.get('log_file', './debug_nodes.log')
@@ -15,9 +25,11 @@ class logger(object):
     def logger_init(self, console_level, file_level, log_file, logger_name):
         file_format = '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
         console_format = '%(name)-12s: %(levelname)-6s %(message)s'
+        logging.getLogger('requests.packages.urllib3.connectionpool').setLevel(logging.WARN)
+        logging.getLogger('urllib3.connectionpool').setLevel(logging.WARN)
         logging.basicConfig(level=file_level,
                             format=file_format,
-                            datefmt='%m-%d %H:%M:%S',
+                            datefmt='%m-%d-%y %H:%M:%S %Z',
                             filename=log_file,
                             filemode='w')
         console = logging.StreamHandler()
@@ -28,34 +40,10 @@ class logger(object):
         console.setFormatter(formatter)
 
         # add rotate handler
-        rotate_handler = RotatingFileHandler(log_file, 
-                                             maxBytes=100000000, 
+        rotate_handler = RotatingFileHandler(log_file,
+                                             maxBytes=100000000,
                                              backupCount=5)
         logger_handle = logging.getLogger(logger_name)
         logger_handle.addHandler(console)
         logger_handle.addHandler(rotate_handler)
-        return logger_handle
-
-    def logger_init_v0(self, console_level, file_level, log_file, logger_name):
-        file_format = '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
-        console_format = '%(name)-12s: %(levelname)-6s %(message)s'
-        logging.basicConfig(level=file_level,
-                            format=file_format,
-                            datefmt='%m-%d %H:%M:%S',
-                            filename=log_file,
-                            filemode='a')
-        console = logging.StreamHandler()
-        console.setLevel(console_level)
-        # set a format which is simpler for console use
-        formatter = logging.Formatter(console_format)
-        # tell the handler to use this format
-        console.setFormatter(formatter)
-        # add the handler to the root logger
-        logging.getLogger('').addHandler(console)
-        # add rotate handler
-        rotate_handler = RotatingFileHandler(log_file, 
-                                             maxBytes=100000000, 
-                                             backupCount=5)
-        logging.getLogger('').addHandler(rotate_handler)
-        logger_handle = logging.getLogger(logger_name)
         return logger_handle


### PR DESCRIPTION
Issue:
We were creating multiple instance of logger handler for the same logger_name so logger matches the logger name and prints for all instances
Also fixing a bug in floatingip get based on uuid
Changed the -v option to control the console level rather than the filelevel since its better to store all debugs in the file
