### PR TITLE
Enhancements to support inet6/bridge/evpn in debugroute vertex

### DIFF
--- a/debugroute.py
+++ b/debugroute.py
@@ -32,11 +32,12 @@ class debugVertexRoute(baseVertex):
     vertex_type = 'route'
     non_config_obj = True
     def __init__(self, prefix=None, vn_fqname=None, ri_fqname=None,
-                 vrouters=None, **kwargs):
+                 vrouters=None, rt_type=None, **kwargs):
         self.vrouters = vrouters
         self.ri_fqname = ri_fqname
         self.vn_fqname = vn_fqname
         self.prefix = prefix
+        self.rt_type = rt_type
         self.ri = dict()
         self.match_kv = {'dummy': 'dummy'}
         super(debugVertexRoute, self).__init__(**kwargs)
@@ -105,11 +106,11 @@ class debugVertexRoute(baseVertex):
     def _get_agent_oper_db(self, introspect, vertex):
         knh = list()
         (exists, route) = introspect.is_route_exists(self.ri[vertex['uuid']],
-                                                    self.prefix)
+                                                    self.prefix, self.rt_type)
         if not exists:
             self.logger.error('Route for %s doesnt exist in VRF %s of agent %s'%(
                           self.prefix, self.ri[vertex['uuid']], introspect._ip))
-        (exists, kroute) = introspect.is_kroute_exists(self.prefix,
+        (exists, kroute) = introspect.is_kroute_exists(self.prefix, self.rt_type,
                                       vrf_fq_name=self.ri[vertex['uuid']])
         if not exists:
             self.logger.error('Route for %s doesnt exist in VRF %s of kernel %s'%(
@@ -122,7 +123,7 @@ class debugVertexRoute(baseVertex):
 
     def _get_control_oper_db(self, introspect, vertex):
         (exists, route) = introspect.is_route_exists(self.ri[vertex['uuid']],
-                                                    self.prefix)
+                                                    self.prefix, self.rt_type)
         if not exists:
             self.logger.error('Route for %s doesnt exist in VRF %s of control %s'%(
                           self.prefix, self.ri[vertex['uuid']], introspect._ip))
@@ -134,6 +135,7 @@ def parse_args(args):
     parser.add_argument('--vn_fqname', help='FQName of the Virtual Network')
     parser.add_argument('--prefix', help='Route prefix to verify')
     parser.add_argument('--vrouters', help='List of vrouters to verify')
+    parser.add_argument('--rt_type', help='Routing Table type where route belongs to (inet/inet6/bridge/evpn)')
     return parser.parse_args(args)
 
 if __name__ == '__main__':

--- a/introspect.py
+++ b/introspect.py
@@ -249,6 +249,9 @@ class ControllerIntrospect(Introspect):
             rt_name = 'evpn'
         else:
             rt_name = None
+            routes = None
+            return(False, routes)
+
         if (rt_type == 'evpn'):
             prefix = address.split(',')
         url_path = 'Snh_ShowRouteReq?x=%s.%s.0'%(vrf_fq_name, rt_name)
@@ -390,6 +393,9 @@ class AgentIntrospect(Introspect):
             rt_name = 'evpn.route'
         else:
             rt_name = None
+            routes = None
+            return (False, routes)
+
         if (rt_type == 'evpn'):
             prefix = address.split(',')
 


### PR DESCRIPTION
Following routing tables are placed in the differen modules as follows
In Agent,
- inet-unicast
- inet6-unicast
- inet4-multicast
- bridge-route
- evpn-route

In Vrouter(kernel),
- inet
- inet6
- bridge

In Controller,
- inet
- inet6
- evpn

Based on the avaialbility of those tables the given prefix along with
the routing table type, will serach the correpsonding table.

The sample commands to search different routing tables as follows,
python debugroute.py --ri_fqname default-domain:admin:local:local
--prefix 02:1c:bf:17:9d:a7 --rt_type bridge
python debugroute.py --ri_fqname default-domain:admin:local:local
--prefix 10.10.10.3 --rt_type inet
python debugroute.py --ri_fqname default-domain:admin:ipv6_nw:ipv6_nw
--prefix fd11::3 --rt_type inet6
python debugroute.py --ri_fqname default-domain:admin:local:local
--prefix 02:1c:bf:17:9d:a7,10.10.10.3 --rt_type evpn